### PR TITLE
Add toggle for auto highlighting

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -23,6 +23,7 @@ export const SELECTORS = {
   statsButton: '#stats-button',
   statsPopup: '.stats-popup',
   bionicToggle: '#bionic-toggle-switch',
+  autoHighlightToggle: '#auto-highlight-toggle-switch',
   closeButton: '.close-button',
   currentTime: '.current-time',
   totalTime: '.total-time',
@@ -36,6 +37,7 @@ export const SELECTORS = {
 export const STORAGE_KEYS = {
   openaiApiKey: 'openaiApiKey',
   bionicEnabled: 'bionicEnabled',
+  autoHighlightEnabled: 'autoHighlightEnabled',
   bionicReadingTime: 'bionicReadingTime',
   bionicReadingArticles: 'bionicReadingArticles'
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -84,14 +84,16 @@ async function showReader(): Promise<void> {
     timerService.startTimer();
     console.log('⏰ Timer started, reader opened');
     
-    // Trigger AI highlighting with a small delay to ensure DOM is ready
-    console.log('🎯 Scheduling AI highlighting...');
-    setTimeout(() => {
-      console.log('🎯 Starting AI highlighting after delay...');
-      console.log('📊 Content element children:', tempContainer.children.length);
-      console.log('📊 Content element HTML preview:', tempContainer.innerHTML.substring(0, 200) + '...');
-      AIHighlightingService.highlightImportantLines(tempContainer).catch(console.error);
-    }, TIMING.aiHighlightDelay);
+    if (stateService.get('isAutoHighlightEnabled')) {
+      // Trigger AI highlighting with a small delay to ensure DOM is ready
+      console.log('🎯 Scheduling AI highlighting...');
+      setTimeout(() => {
+        console.log('🎯 Starting AI highlighting after delay...');
+        console.log('📊 Content element children:', tempContainer.children.length);
+        console.log('📊 Content element HTML preview:', tempContainer.innerHTML.substring(0, 200) + '...');
+        AIHighlightingService.highlightImportantLines(tempContainer).catch(console.error);
+      }, TIMING.aiHighlightDelay);
+    }
   } catch (error) {
     console.error('❌ Error parsing article:', error);
   }

--- a/src/services/reader-state.service.ts
+++ b/src/services/reader-state.service.ts
@@ -17,6 +17,7 @@ export interface ReaderState {
   historicalArticles: HistoricalArticle[];
   isStatsOpen: boolean;
   isBionicEnabled: boolean;
+  isAutoHighlightEnabled: boolean;
 }
 
 export class ReaderStateService {
@@ -35,7 +36,8 @@ export class ReaderStateService {
       currentArticleTime: 0,
       historicalArticles: StorageService.getHistoricalArticles(),
       isStatsOpen: false,
-      isBionicEnabled: false
+      isBionicEnabled: false,
+      isAutoHighlightEnabled: false
     };
   }
 
@@ -83,6 +85,14 @@ export class ReaderStateService {
   async initializeBionicState(): Promise<void> {
     const enabled = await StorageService.getBionicEnabled();
     this.state.isBionicEnabled = enabled;
+  }
+
+  /**
+   * Initialize auto highlight state from storage
+   */
+  async initializeAutoHighlightState(): Promise<void> {
+    const enabled = await StorageService.getAutoHighlightEnabled();
+    this.state.isAutoHighlightEnabled = enabled;
   }
 
   /**

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -35,11 +35,31 @@ export class StorageService {
   }
 
   /**
+   * Get auto highlight enabled state from Chrome storage
+   */
+  static async getAutoHighlightEnabled(): Promise<boolean> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.get([STORAGE_KEYS.autoHighlightEnabled], (result) => {
+        resolve(result[STORAGE_KEYS.autoHighlightEnabled] || false);
+      });
+    });
+  }
+
+  /**
    * Set bionic reading enabled state in Chrome storage
    */
   static async setBionicEnabled(enabled: boolean): Promise<void> {
     return new Promise((resolve) => {
       chrome.storage.sync.set({ [STORAGE_KEYS.bionicEnabled]: enabled }, resolve);
+    });
+  }
+
+  /**
+   * Set auto highlight enabled state in Chrome storage
+   */
+  static async setAutoHighlightEnabled(enabled: boolean): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.set({ [STORAGE_KEYS.autoHighlightEnabled]: enabled }, resolve);
     });
   }
 


### PR DESCRIPTION
## Summary
- add selector and storage key for auto highlighting
- persist auto highlight flag in storage service
- track auto highlighting state in reader state service
- add toggle to reader overlay header
- gate AI highlighting on the new state

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684719fa8378832381917defe2935c44