### PR TITLE
Add multi-level translator and settings menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Research Bites is a browser extension that presents articles in a clean overlay 
 
 - **Bionic Reading** – emphasises the first letters of words for easier scanning.
 - **AI-Powered Highlighting** – uses OpenAI to identify and highlight the most important sentences in articles.
-- **Jargon Translator** – rewrites complex paragraphs in plain language using your OpenAI API key and remembers translations for instant toggling.
+- **Jargon Translator** – rewrites complex paragraphs in plain language with selectable levels (High School, College, Academia) using your OpenAI API key and remembers translations for instant toggling.
 - **Reading Statistics** – tracks reading time and maintains a history of articles read.
 - Extracts readable content using Mozilla's Readability library.
 - Distraction-free overlay with customizable reading experience.
 - Keyboard shortcuts (Esc to exit) and toolbar icon for quick access.
+- Bionic Reading and Auto Highlight toggles are accessible from a compact settings menu.
 
 ## Repository Structure
 
@@ -105,7 +106,7 @@ Emphasizes the beginning of words to help readers scan text more efficiently. Ca
 Uses OpenAI's GPT-4 mini model to identify 5-10 most important sentences in an article. Falls back to keyword-based highlighting if API is unavailable.
 
 ### Jargon Translator
-Streams simplified versions of each paragraph using the same OpenAI API key. Once a paragraph is translated it is cached so subsequent toggles are instant. Enabling the translator also applies a clean sans-serif font for better readability.
+Streams simplified versions of each paragraph using the same OpenAI API key. Choose between **High School**, **College**, and **Academia** levels in the reader controls. Once a paragraph is translated it is cached so subsequent toggles are instant. Enabling the translator also applies a clean sans-serif font for better readability.
 
 ### Reading Statistics
 - Tracks time spent reading current article

--- a/docs/jargon-translator.md
+++ b/docs/jargon-translator.md
@@ -8,6 +8,7 @@ The Jargon Translator rewrites complex paragraphs in plain language and remember
 - **Caching**: Translated paragraphs are stored in `data-translated-text` attributes so switching the toggle doesn't retranslate.
 - **Restoration**: Original text is kept in `data-original-text` attributes, allowing the translator to revert to the exact source wording.
 - **Design**: When enabled the reader container receives a `.jargon-free` class that applies a clean sans-serif font and relaxed line height.
+- **Levels**: Select *High School*, *College*, or *Academia* to control how much the text is simplified.
 
 ## Implementation Details
 

--- a/src/components/reader-overlay.ts
+++ b/src/components/reader-overlay.ts
@@ -31,14 +31,15 @@ export class ReaderOverlay {
     overlay.innerHTML = `
       <div class="reader-container">
         <div class="reader-controls">
-          <button id="stats-button" class="icon-button stats-button">
-            <svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M2 3C2 2.44772 2.44772 2 3 2H17C17.5523 2 18 2.44772 18 3V17C18 17.5523 17.5523 18 17 18H3C2.44772 18 2 17.5523 2 17V3Z" stroke="currentColor" stroke-width="1.5"/>
-              <path d="M6 6H14M6 10H14M6 14H10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          <button id="stats-button" class="icon-button stats-button" title="Menu & Stats">
+            <svg width="18" height="14" viewBox="0 0 18 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M1 1H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M1 7H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M1 13H17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
             </svg>
           </button>
           <div class="bionic-toggle-container jargon-toggle-container">
-            <label class="bionic-toggle-label">Jargon Translator</label>
+            <label class="bionic-toggle-label">Jargon Free</label>
             <label class="bionic-toggle">
               <input type="checkbox" id="jargon-toggle-switch">
               <span class="toggle-slider"></span>
@@ -48,28 +49,6 @@ export class ReaderOverlay {
               <option value="college">College</option>
               <option value="academia">Academia</option>
             </select>
-          </div>
-          <button id="settings-button" class="icon-button settings-button" title="Settings">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 15.5A3.5 3.5 0 1 0 12 8.5a3.5 3.5 0 0 0 0 7z" stroke="currentColor" stroke-width="1.5"/>
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 10 5.09V5a2 2 0 1 1 4 0v.09c0 .68.39 1.3 1 1.51a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06c-.41.41-.53 1-.33 1.54.21.54.74.9 1.33.9H21a2 2 0 1 1 0 4h-.09c-.59 0-1.12.36-1.33.9z" stroke="currentColor" stroke-width="1.5"/>
-            </svg>
-          </button>
-          <div class="settings-menu">
-            <div class="bionic-toggle-container">
-              <label class="bionic-toggle-label">Bionic Reading</label>
-              <label class="bionic-toggle">
-                <input type="checkbox" id="bionic-toggle-switch">
-                <span class="toggle-slider"></span>
-              </label>
-            </div>
-            <div class="bionic-toggle-container auto-highlight-toggle-container">
-              <label class="bionic-toggle-label">Auto Highlight</label>
-              <label class="bionic-toggle">
-                <input type="checkbox" id="auto-highlight-toggle-switch">
-                <span class="toggle-slider"></span>
-              </label>
-            </div>
           </div>
           <button class="icon-button close-button" title="Exit Reader Mode (Esc)">×</button>
         </div>
@@ -120,6 +99,7 @@ export class ReaderOverlay {
     const levelSelect = document.getElementById('translator-level-select') as HTMLSelectElement;
     if (levelSelect) {
       levelSelect.value = this.stateService.get('translatorLevel');
+      levelSelect.classList.toggle('show', jargonToggle?.checked);
     }
 
     // Setup event listeners
@@ -173,9 +153,13 @@ export class ReaderOverlay {
 
         const content = document.querySelector(SELECTORS.readerContent) as HTMLElement;
         const container = document.querySelector(SELECTORS.readerContainer) as HTMLElement | null;
+        const levelSel = document.getElementById('translator-level-select') as HTMLSelectElement;
+        if (levelSel) {
+          levelSel.classList.toggle('show', isEnabled);
+        }
         if (content && this.stateService.get('isOpen')) {
           if (isEnabled) {
-            await JargonTranslationService.translateContent(content, this.stateService.get('translatorLevel'));
+            await JargonTranslationService.translateContent(content, this.stateService.get('translatorLevel') as TranslatorLevel);
             container?.classList.add('jargon-free');
           } else {
             JargonTranslationService.restoreOriginal(content);
@@ -193,34 +177,18 @@ export class ReaderOverlay {
     const levelSelect = document.getElementById('translator-level-select') as HTMLSelectElement;
     if (levelSelect) {
       levelSelect.addEventListener('change', async (event) => {
-        const level = (event.target as HTMLSelectElement).value;
+        const level = (event.target as HTMLSelectElement).value as TranslatorLevel;
         this.stateService.set('translatorLevel', level);
         await StorageService.setTranslatorLevel(level);
         if (this.stateService.get('isOpen') && this.stateService.get('isJargonTranslatorEnabled')) {
           const content = document.querySelector(SELECTORS.readerContent) as HTMLElement;
           if (content) {
             JargonTranslationService.restoreOriginal(content);
-            await JargonTranslationService.translateContent(content, level as TranslatorLevel);
+            await JargonTranslationService.translateContent(content, level);
             if (this.stateService.get('isBionicEnabled')) {
               BionicReadingService.toggleBionicReading(content, true);
             }
           }
-        }
-      });
-    }
-
-    const settingsButton = document.getElementById('settings-button');
-    const settingsMenu = document.querySelector('.settings-menu') as HTMLElement | null;
-    if (settingsButton && settingsMenu) {
-      settingsButton.addEventListener('click', (event) => {
-        event.stopPropagation();
-        const open = settingsMenu.style.display === 'block';
-        settingsMenu.style.display = open ? 'none' : 'block';
-      });
-      settingsMenu.addEventListener('click', (e) => e.stopPropagation());
-      document.addEventListener('click', () => {
-        if (settingsMenu.style.display === 'block') {
-          settingsMenu.style.display = 'none';
         }
       });
     }

--- a/src/components/stats-popup.ts
+++ b/src/components/stats-popup.ts
@@ -40,6 +40,20 @@ export class StatsPopup {
         <div class="history-list" style="display: none;">
           <div class="history-urls"></div>
         </div>
+        <div class="bionic-toggle-container" style="margin-top:8px;">
+          <label class="bionic-toggle-label">Bionic Reading</label>
+          <label class="bionic-toggle">
+            <input type="checkbox" id="bionic-toggle-switch">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+        <div class="bionic-toggle-container auto-highlight-toggle-container">
+          <label class="bionic-toggle-label">Auto Highlight</label>
+          <label class="bionic-toggle">
+            <input type="checkbox" id="auto-highlight-toggle-switch">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
       </div>
     `;
 
@@ -67,6 +81,9 @@ export class StatsPopup {
         }
       });
     }
+
+    // Prevent clicks inside the popup from closing it via the stats button handler
+    popup.addEventListener('click', (e) => e.stopPropagation());
   }
 
   /**

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -72,8 +72,10 @@ export const READER_STYLES = `
     align-items: center;
     justify-content: flex-start;
     flex-wrap: nowrap;
+    gap: 16px;
     z-index: 10001;
     width: calc(100% - 6rem);
+    line-height: 1;
   }
   .bionic-toggle-container {
     display: flex;
@@ -91,6 +93,7 @@ export const READER_STYLES = `
     font-weight: 500;
     color: #2c2c2c;
     user-select: none;
+    text-transform: none;
   }
   .bionic-toggle {
     position: relative;
@@ -136,11 +139,28 @@ export const READER_STYLES = `
     box-shadow: 0 0 0 3px rgba(139, 115, 85, 0.3);
   }
   .translator-select {
-    margin-left: 8px;
-    padding: 4px 6px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
+    display: none;
+    padding: 4px 32px 4px 10px;
+    border: 1px solid #d0d0d0;
+    border-radius: 8px;
     font-size: 14px;
+    height: 28px;
+    line-height: 19px;
+    background: #ffffff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8' fill='none'%3E%3Cpath d='M1 1L6 6L11 1' stroke='%232c2c2c' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E") no-repeat right 10px center;
+    background-size: 12px 8px;
+    color: #2c2c2c;
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .translator-select.show {
+    display: inline-block;
+  }
+  .translator-select:focus {
+    outline: none;
+    border-color: #8b7355;
+    box-shadow: 0 0 0 2px rgba(139, 115, 85, 0.25);
   }
   .settings-menu {
     position: absolute;
@@ -190,13 +210,18 @@ export const READER_STYLES = `
     border-radius: 8px !important;
   }
   .icon-button:hover {
-    background: rgba(0, 0, 0, 0.05);
-    transform: translateY(-1px);
+    background: none;
+    transform: translateY(-2px);
     box-shadow: none;
   }
   .icon-button:active {
     transform: translateY(0);
     box-shadow: none;
+  }
+  /* Fine-tune stats button hover separately if needed */
+  .stats-button:hover {
+    background: none;
+    transform: scale(1.05);
   }
   /* Ensure bionic strong tags don't interfere with highlights */
   .reader-content strong {

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -135,6 +135,27 @@ export const READER_STYLES = `
   .bionic-toggle input:focus + .toggle-slider {
     box-shadow: 0 0 0 3px rgba(139, 115, 85, 0.3);
   }
+  .translator-select {
+    margin-left: 8px;
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    font-size: 14px;
+  }
+  .settings-menu {
+    position: absolute;
+    right: 3rem;
+    top: calc(100% + 8px);
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    padding: 12px;
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+    display: none;
+    flex-direction: column;
+    gap: 12px;
+  }
   .icon-button {
     width: 32px;
     height: 32px;

--- a/src/config/ai-prompts.ts
+++ b/src/config/ai-prompts.ts
@@ -21,10 +21,21 @@ ${articleText}
 Output format: <hl prefix="..." suffix="...">Important sentence here</hl><hl prefix="..." suffix="...">Another important sentence</hl>`
 };
 
-export const JARGON_TRANSLATION_PROMPTS = {
-  system: `Rewrite the following academic text in plain language for a general audience (age 16-20). Avoid any jargons at all time and ensure the audience can understand the fundamentals. Make sure you return without any commentary text.`,
+export type TranslatorLevel = 'highSchool' | 'college' | 'academia';
 
-  user: (text: string) => `${text}`
+export const JARGON_TRANSLATION_PROMPTS: Record<TranslatorLevel, { system: string; user: (text: string) => string }> = {
+  highSchool: {
+    system: `Rewrite the following text in simple language for a high school student (age 14-18). Remove complex jargon and keep sentences short and clear without extra commentary.`,
+    user: (text: string) => `${text}`
+  },
+  college: {
+    system: `Rewrite the following text for readers with some college experience. Use accessible language while keeping key details intact. Do not add any commentary.`,
+    user: (text: string) => `${text}`
+  },
+  academia: {
+    system: `Clarify the following text for an academic audience. Reduce unnecessary jargon but preserve technical nuance and formal tone. Return only the rewritten text.`,
+    user: (text: string) => `${text}`
+  }
 };
 
 export const AUTO_HIGHLIGHT_CONFIG = {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -26,6 +26,9 @@ export const SELECTORS = {
   bionicToggle: '#bionic-toggle-switch',
   autoHighlightToggle: '#auto-highlight-toggle-switch',
   jargonToggle: '#jargon-toggle-switch',
+  translatorLevelSelect: '#translator-level-select',
+  settingsButton: '#settings-button',
+  settingsMenu: '.settings-menu',
   closeButton: '.close-button',
   currentTime: '.current-time',
   totalTime: '.total-time',
@@ -41,6 +44,7 @@ export const STORAGE_KEYS = {
   bionicEnabled: 'bionicEnabled',
   autoHighlightEnabled: 'autoHighlightEnabled',
   jargonTranslatorEnabled: 'jargonTranslatorEnabled',
+  translatorLevel: 'translatorLevel',
   bionicReadingTime: 'bionicReadingTime',
   bionicReadingArticles: 'bionicReadingArticles'
 };

--- a/src/services/jargon-translation.service.ts
+++ b/src/services/jargon-translation.service.ts
@@ -4,14 +4,14 @@
  */
 
 import { StorageService } from './storage.service';
-import { JARGON_TRANSLATION_PROMPTS, JARGON_TRANSLATION_CONFIG } from '../config/ai-prompts';
+import { JARGON_TRANSLATION_PROMPTS, JARGON_TRANSLATION_CONFIG, TranslatorLevel } from '../config/ai-prompts';
 
 export class JargonTranslationService {
 
   /**
    * Translate all paragraphs in the container using streaming
    */
-  static async translateContent(container: HTMLElement): Promise<void> {
+  static async translateContent(container: HTMLElement, level: TranslatorLevel): Promise<void> {
     const apiKey = await StorageService.getOpenAIApiKey();
     if (!apiKey) {
       console.warn('OpenAI API key not configured');
@@ -32,7 +32,7 @@ export class JargonTranslationService {
 
       p.textContent = '';
       try {
-        const translated = await this.streamTranslation(p, original, apiKey);
+        const translated = await this.streamTranslation(p, original, apiKey, level);
         p.dataset.translatedText = translated;
       } catch (err) {
         console.error('Jargon translation failed:', err);
@@ -54,7 +54,7 @@ export class JargonTranslationService {
     }
   }
 
-  private static async streamTranslation(element: HTMLElement, text: string, apiKey: string): Promise<string> {
+  private static async streamTranslation(element: HTMLElement, text: string, apiKey: string, level: TranslatorLevel): Promise<string> {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -64,8 +64,8 @@ export class JargonTranslationService {
       body: JSON.stringify({
         model: JARGON_TRANSLATION_CONFIG.model,
         messages: [
-          { role: 'system', content: JARGON_TRANSLATION_PROMPTS.system },
-          { role: 'user', content: JARGON_TRANSLATION_PROMPTS.user(text) }
+          { role: 'system', content: JARGON_TRANSLATION_PROMPTS[level].system },
+          { role: 'user', content: JARGON_TRANSLATION_PROMPTS[level].user(text) }
         ],
         temperature: JARGON_TRANSLATION_CONFIG.temperature,
         max_tokens: JARGON_TRANSLATION_CONFIG.maxTokens,

--- a/src/services/jargon-translation.service.ts
+++ b/src/services/jargon-translation.service.ts
@@ -51,6 +51,8 @@ export class JargonTranslationService {
       if (original !== undefined) {
         p.textContent = original;
       }
+      // Remove cached translation so it can regenerate with a new level
+      delete p.dataset.translatedText;
     }
   }
 

--- a/src/services/reader-state.service.ts
+++ b/src/services/reader-state.service.ts
@@ -4,6 +4,7 @@
  */
 
 import { StorageService, HistoricalArticle } from './storage.service';
+import { TranslatorLevel } from '../config/ai-prompts';
 
 export interface ReaderState {
   isOpen: boolean;
@@ -19,6 +20,7 @@ export interface ReaderState {
   isBionicEnabled: boolean;
   isAutoHighlightEnabled: boolean;
   isJargonTranslatorEnabled: boolean;
+  translatorLevel: TranslatorLevel;
 }
 
 export class ReaderStateService {
@@ -39,7 +41,8 @@ export class ReaderStateService {
       isStatsOpen: false,
       isBionicEnabled: false,
       isAutoHighlightEnabled: false,
-      isJargonTranslatorEnabled: false
+      isJargonTranslatorEnabled: false,
+      translatorLevel: 'highSchool'
     };
   }
 
@@ -106,6 +109,13 @@ export class ReaderStateService {
     // Always start with jargon translator disabled
     this.state.isJargonTranslatorEnabled = false;
     await StorageService.setJargonTranslatorEnabled(false);
+  }
+
+  /**
+   * Initialize translator level from storage
+   */
+  async initializeTranslatorLevel(): Promise<void> {
+    this.state.translatorLevel = await StorageService.getTranslatorLevel() as TranslatorLevel;
   }
 
   /**

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -57,6 +57,17 @@ export class StorageService {
   }
 
   /**
+   * Get translator level from Chrome storage
+   */
+  static async getTranslatorLevel(): Promise<string> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.get([STORAGE_KEYS.translatorLevel], (result) => {
+        resolve(result[STORAGE_KEYS.translatorLevel] || 'highSchool');
+      });
+    });
+  }
+
+  /**
    * Set bionic reading enabled state in Chrome storage
    */
   static async setBionicEnabled(enabled: boolean): Promise<void> {
@@ -80,6 +91,15 @@ export class StorageService {
   static async setJargonTranslatorEnabled(enabled: boolean): Promise<void> {
     return new Promise((resolve) => {
       chrome.storage.sync.set({ [STORAGE_KEYS.jargonTranslatorEnabled]: enabled }, resolve);
+    });
+  }
+
+  /**
+   * Set translator level in Chrome storage
+   */
+  static async setTranslatorLevel(level: string): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.sync.set({ [STORAGE_KEYS.translatorLevel]: level }, resolve);
     });
   }
 


### PR DESCRIPTION
## Summary
- support translator levels and expose prompts for high school, college, and academia
- store translator level in extension settings
- add dropdown and settings menu UI
- hide bionic and auto highlight toggles under a gear menu
- document translation levels and updated feature list

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684896f3bcc083238318a1baf0b5abd1