### PR TITLE
Add manual highlight support

### DIFF
--- a/docs/highlight-feature.md
+++ b/docs/highlight-feature.md
@@ -35,3 +35,9 @@ The extension automatically highlights key sentences when you enter the reader m
 - Works alongside bionic reading feature without conflicts
 - Graceful degradation with simulation fallback
 
+## Manual Highlighting
+
+- Select any text in reader mode to reveal a **Highlight** button
+- Clicking the button wraps the selection in `<mark class="user-highlight">`
+- Highlights are saved per URL so they reappear next time you open the article
+

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -233,6 +233,9 @@ export const READER_STYLES = `
     background: none;
     color: inherit;
   }
+  mark.user-highlight {
+    background-color: #ffeb3b;
+  }
   /* 4K and Ultra-wide displays (3840px+) */
   @media (min-width: 3840px) {
     .reader-container {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -46,7 +46,8 @@ export const STORAGE_KEYS = {
   jargonTranslatorEnabled: 'jargonTranslatorEnabled',
   translatorLevel: 'translatorLevel',
   bionicReadingTime: 'bionicReadingTime',
-  bionicReadingArticles: 'bionicReadingArticles'
+  bionicReadingArticles: 'bionicReadingArticles',
+  manualHighlights: 'manualHighlights'
 };
 
 // Timing constants

--- a/src/content.ts
+++ b/src/content.ts
@@ -9,6 +9,7 @@ import { TimerService } from './services/timer.service';
 import { BionicReadingService } from './services/bionic-reading.service';
 import { AIHighlightingService } from './services/ai-highlighting.service';
 import { StorageService } from './services/storage.service';
+import { ManualHighlightService } from './services/manual-highlight.service';
 import { ReaderOverlay } from './components/reader-overlay';
 import { TIMING, SELECTORS } from './config/constants';
 
@@ -71,6 +72,10 @@ async function showReader(): Promise<void> {
     }
 
     content.appendChild(tempContainer);
+
+    // Initialize manual highlighting
+    ManualHighlightService.init(tempContainer);
+    ManualHighlightService.applyStoredHighlights(tempContainer);
     
     // Add current article to history
     stateService.addArticleToHistory(

--- a/src/services/manual-highlight.service.ts
+++ b/src/services/manual-highlight.service.ts
@@ -1,0 +1,158 @@
+import { StorageService } from './storage.service';
+
+export class ManualHighlightService {
+  private static button: HTMLButtonElement | null = null;
+  private static container: HTMLElement | null = null;
+
+  static init(container: HTMLElement): void {
+    this.container = container;
+    if (!this.button) this.createButton();
+    container.addEventListener('mouseup', (e) => {
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed && container.contains(selection.anchorNode)) {
+        const rect = selection.getRangeAt(0).getBoundingClientRect();
+        this.showButton(rect.right + window.scrollX, rect.bottom + window.scrollY);
+      } else {
+        this.hideButton();
+      }
+    });
+  }
+
+  static applyStoredHighlights(container: HTMLElement): void {
+    const url = window.location.href;
+    const highlights = StorageService.getManualHighlights(url);
+    highlights.forEach(text => {
+      this.highlightText(container, text);
+    });
+  }
+
+  private static createButton(): void {
+    const btn = document.createElement('button');
+    btn.id = 'rb-highlight-btn';
+    btn.textContent = 'Highlight';
+    btn.style.position = 'absolute';
+    btn.style.display = 'none';
+    btn.style.zIndex = '10003';
+    btn.style.padding = '4px 8px';
+    btn.style.fontSize = '12px';
+    btn.style.background = '#ffeb3b';
+    btn.style.border = '1px solid #d0d0d0';
+    btn.style.borderRadius = '4px';
+    btn.style.cursor = 'pointer';
+    btn.addEventListener('mousedown', (e) => e.preventDefault());
+    btn.addEventListener('click', () => this.applyHighlight());
+    document.body.appendChild(btn);
+    this.button = btn;
+  }
+
+  private static showButton(x: number, y: number): void {
+    if (!this.button) return;
+    this.button.style.top = `${y + 5}px`;
+    this.button.style.left = `${x + 5}px`;
+    this.button.style.display = 'block';
+  }
+
+  private static hideButton(): void {
+    if (this.button) {
+      this.button.style.display = 'none';
+    }
+  }
+
+  private static applyHighlight(): void {
+    if (!this.container) return;
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) return;
+    const range = selection.getRangeAt(0);
+    if (!this.container.contains(range.commonAncestorContainer)) return;
+    const contents = range.extractContents();
+    const mark = document.createElement('mark');
+    mark.className = 'user-highlight';
+    mark.appendChild(contents);
+    range.insertNode(mark);
+    const text = mark.textContent || '';
+    StorageService.addManualHighlight(window.location.href, text);
+    selection.removeAllRanges();
+    this.hideButton();
+  }
+
+  private static highlightText(root: HTMLElement, text: string): boolean {
+    const blockElements = root.querySelectorAll('p, div, li, h1, h2, h3, h4, h5, h6, blockquote');
+    for (const block of Array.from(blockElements)) {
+      const { nodes, totalText } = this.collectTextNodes(block);
+      const flexiblePattern = this.escapeRegex(text).replace(/\s+/g, "\\s+");
+      const regex = new RegExp(flexiblePattern, 'i');
+      const match = totalText.match(regex);
+      if (match && typeof match.index === 'number') {
+        let start = match.index;
+        let end = match.index + match[0].length;
+        while (start < end && /\s/.test(totalText[start])) start++;
+        while (end > start && /\s/.test(totalText[end - 1])) end--;
+        if (this.highlightRange(nodes, start, end)) return true;
+      }
+    }
+    return false;
+  }
+
+  private static collectTextNodes(
+    node: Node,
+    textNodes: { node: Node; text: string; offset: number }[] = [],
+    currentOffset: number = 0
+  ): { nodes: { node: Node; text: string; offset: number }[]; totalText: string } {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent || '';
+      textNodes.push({ node, text, offset: currentOffset });
+      return { nodes: textNodes, totalText: text };
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      node.nodeName !== 'MARK' &&
+      node.nodeName !== 'SCRIPT' &&
+      node.nodeName !== 'STYLE'
+    ) {
+      let totalText = '';
+      const children = Array.from(node.childNodes);
+      for (const child of children) {
+        const result = this.collectTextNodes(child, textNodes, currentOffset + totalText.length);
+        totalText += result.totalText;
+      }
+      return { nodes: textNodes, totalText };
+    }
+    return { nodes: textNodes, totalText: '' };
+  }
+
+  private static highlightRange(
+    nodes: { node: Node; text: string; offset: number }[],
+    startOffset: number,
+    endOffset: number
+  ): boolean {
+    let highlighted = false;
+    for (const { node, text, offset } of nodes) {
+      const nodeStart = offset;
+      const nodeEnd = offset + text.length;
+      if (nodeEnd <= startOffset || nodeStart >= endOffset) continue;
+      const highlightStart = Math.max(0, startOffset - nodeStart);
+      const highlightEnd = Math.min(text.length, endOffset - nodeStart);
+      if (highlightStart < highlightEnd && node.nodeType === Node.TEXT_NODE) {
+        const textNode = node as Text;
+        const parent = textNode.parentNode;
+        if (parent) {
+          const before = text.substring(0, highlightStart);
+          const middle = text.substring(highlightStart, highlightEnd);
+          const after = text.substring(highlightEnd);
+          if (before) parent.insertBefore(document.createTextNode(before), textNode);
+          const mark = document.createElement('mark');
+          mark.className = 'user-highlight';
+          mark.textContent = middle;
+          parent.insertBefore(mark, textNode);
+          if (after) parent.insertBefore(document.createTextNode(after), textNode);
+          parent.removeChild(textNode);
+          highlighted = true;
+        }
+      }
+    }
+    return highlighted;
+  }
+
+  private static escapeRegex(text: string): string {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}

--- a/src/services/storage.service.ts
+++ b/src/services/storage.service.ts
@@ -149,4 +149,33 @@ export class StorageService {
       this.setHistoricalArticles(articles);
     }
   }
-} 
+
+  /**
+   * Get manual highlights for a URL from localStorage
+   */
+  static getManualHighlights(url: string): string[] {
+    try {
+      return JSON.parse(localStorage.getItem(`${STORAGE_KEYS.manualHighlights}:${url}`) || '[]');
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Save manual highlights for a URL to localStorage
+   */
+  static setManualHighlights(url: string, highlights: string[]): void {
+    localStorage.setItem(`${STORAGE_KEYS.manualHighlights}:${url}`, JSON.stringify(highlights));
+  }
+
+  /**
+   * Add a manual highlight to a URL
+   */
+  static addManualHighlight(url: string, text: string): void {
+    const highlights = this.getManualHighlights(url);
+    if (!highlights.includes(text)) {
+      highlights.push(text);
+      this.setManualHighlights(url, highlights);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- support saving manual highlights per URL via `StorageService`
- add new constant for manual highlights
- implement `ManualHighlightService` for user-driven highlighting
- wire up manual highlighting in the content script
- style manual highlights
- document manual highlighting feature

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a506e9abc83239d8e855b2ddcba70